### PR TITLE
dev: Correção de problemas ao fazer build das query strings

### DIFF
--- a/TotalVoice/QueryString.cs
+++ b/TotalVoice/QueryString.cs
@@ -26,7 +26,7 @@ namespace TotalVoice
 
         public string Build()
         {
-            return "?" + HttpUtility.UrlEncode(string.Join("&", _query.Select(Item => string.Format("{0}={1}", Item.Key, Item.Value))));
+            return "?" + string.Join("&", _query.Select(Item => string.Format("{0}={1}", Item.Key, HttpUtility.UrlEncode(Item.Value.ToString()))));
         }
     }
 }


### PR DESCRIPTION
Correção de problemas ao fazer build das query strings, antes estava enviando uma querystring com caracteres %3d %26 pois estava codificando toda a URL sendo que só é necessário codificar o valor e não a string completa.